### PR TITLE
ElvUI version checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Add addons to addon_master_list.example.json like so:
 
     {
     "DBM" : {
-        "location" : "cf", # "cf" for a CurseForge addon, "tukui" for ElvUI, and "tsm" for TradeSkillMaster mods.
-        "anchor_link" : "https://www.curseforge.com/wow/addons/deadly-boss-mods", # landing page for CF mods (not needed for direct download addons)
+        "location" : "cf", # "cf" for a CurseForge addon, "elvui" for ElvUI, and "tsm" for TradeSkillMaster mods.
+        "anchor_link" : "https://www.curseforge.com/wow/addons/deadly-boss-mods", # landing page for CF mods
         "dl_url" : "https://www.curseforge.com/wow/addons/deadly-boss-mods/download", # download page (required for all addons)
         "last_updated" : "" # leave blank. The script will populate this field on first run.
     },

--- a/addon_master_list.example.json
+++ b/addon_master_list.example.json
@@ -70,10 +70,10 @@
     },
 
     "ELVUI" : {
-        "location" : "tukui",
-        "anchor_link" : "https://www.tukui.org/download.php?ui=elvui",
-        "dl_url" : "https://www.tukui.org/downloads/elvui-12.99.zip",
-        "last_updated" : ""
+        "location" : "elvui",
+        "anchor_link" : "https://www.tukui.org/welcome.php",
+        "dl_url" : "https://www.tukui.org/downloads/elvui-",
+        "current_version" : ""
     },
 
     "TSM" : {

--- a/main.py
+++ b/main.py
@@ -125,7 +125,7 @@ def main():
         webbrowser.open_new_tab(url)
         sleep(2)
         dl_dir_count += 1
-    sleep(5) # Default is 2 for fast connections (over 25MBs) Wait for two more seconds and hope downloads are finished
+    sleep(2) # Default is 2 for fast connections (over 25MBs) Wait for two more seconds and hope downloads are finished
 
     addon_zips = []
 
@@ -241,7 +241,6 @@ def start_browser():
     return browser
     
 def get_update_time(url, ublock_xpi_path):
-
     browser = start_browser()
 
     if os.name == 'nt':
@@ -262,7 +261,13 @@ def get_update_time(url, ublock_xpi_path):
 def get_version_elvui(url, ublock_xpi_path):
     driver = start_browser()
 
-    driver.install_addon(ublock_xpi_path)
+    if os.name == 'nt':
+        # Windows panics if we don't pass this as a raw string
+        ublock = fr"{ublock_xpi_path}"
+    else:
+        ublock = ublock_xpi_path
+
+    driver.install_addon(ublock)
     driver.get(url)
 
     version = [my_elem.get_attribute("innerText") for my_elem in WebDriverWait(driver, 20).until(EC.visibility_of_all_elements_located((By.XPATH, "/html/body/div[2]/div/div/ul/li/div[4]/div/a[2]/span")))]

--- a/main.py
+++ b/main.py
@@ -4,10 +4,12 @@ import webbrowser
 import shutil
 import json
 import configparser
+from time import sleep, time
 from selenium import webdriver
 from selenium.webdriver import FirefoxOptions
 from selenium.webdriver.common.by import By
-from time import sleep, time
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 class colors:
     GREEN = '\033[92m'
@@ -61,13 +63,18 @@ def main():
             current_version_time = get_update_time(name['anchor_link'], ublock_xpi_path)
             if current_version_time != name['last_updated']:
                 url_list.append(name['dl_url'])
-                to_be_updated.append(name)
+                to_be_updated.append(key)
                 name['last_updated'] = current_version_time
             else:
                 continue
-        # elif name['location'] == 'tukui':
-        #     print(f'Processing {key}...')
-        #     current_version_time = get_version_tukui(name['anchor_link'], ublock_xpi_path)
+        elif name['location'] == 'elvui':
+            print(f'Processing {key}...')
+            current_version = get_version_elvui(name['anchor_link'], ublock_xpi_path)
+            if current_version != name['version']:
+                dl_url = (f"{name['dl_url']}{current_version}.zip")
+                url_list.append(dl_url)
+                to_be_updated.append(key)
+                name['version'] = current_version
         else:
             print(f'Processing {key}...')
             url_list.append(name['dl_url'])
@@ -252,22 +259,19 @@ def get_update_time(url, ublock_xpi_path):
 
     return last_updated
 
-# def get_version_tukui(url, ublock_xpi_path):
-#     browser = start_browser()
+def get_version_elvui(url, ublock_xpi_path):
+    driver = start_browser()
 
-#     if os.name == 'nt':
-#         ublock = fr"{ublock_xpi_path}"
-#     else:
-#         ublock = ublock_xpi_path
+    driver.install_addon(ublock_xpi_path)
+    driver.get(url)
 
-#     browser.install_addon(ublock)
-#     browser.get(url)
+    version = [my_elem.get_attribute("innerText") for my_elem in WebDriverWait(driver, 20).until(EC.visibility_of_all_elements_located((By.XPATH, "/html/body/div[2]/div/div/ul/li/div[4]/div/a[2]/span")))]
 
-#     xpath = browser.find_element(By.XPATH, "//b[@class='Premium']")
-#     last_updated = xpath.text
-#     browser.close()
+    version = (version[0])
+    
+    driver.close()
 
-#     return last_updated
+    return version
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
implemented ElvUI version checking using Selenium to pull the version number off of the Tukui landing page. The ElvUI direct download link changes with each version number, so if the Tukui ElvUI version number is different than the one in master_addon_list.json, use the new version number to generate the download URL.