### PR TITLE
Various optimizations and bug fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Underwolf is my best answer to updating my World of Warcraft addons, both on and off CurseForge after the retirement of the CurseForge API (staying away from the CurseForge application). 
 
-**This software is still in pre-release, and there are bugs. Pull requests are welcome.**
+**This software is still in pre-release, and there may be bugs. Pull requests are welcome. Please report any issues you encounter.**
 
 It utilizes Python's built-in webbrowser library to navigate to [CurseForge](https://www.curseforge.com/) download pages (as well as other direct download URLs, such as [Tukui](https://www.tukui.org) and [Trade Skill Master](https://www.tradeskillmaster.com/)) and download the specified addons, unzip them, and move them into the WoW addon folder. The script utilizes Selenium for version checking (version checking is only implemented on CurseForge addons and ElvUI).
 

--- a/addon_master_list.json
+++ b/addon_master_list.json
@@ -74,5 +74,19 @@
         "anchor_link" : "https://www.tukui.org/welcome.php",
         "dl_url" : "https://www.tukui.org/downloads/elvui-",
         "current_version" : ""
+    },
+
+    "TSM" : {
+        "location" : "tsm",
+        "anchor_link" : "",
+        "dl_url" : "https://www.tradeskillmaster.com/download/TradeSkillMaster.zip",
+        "last_updated" : ""
+    },
+
+    "TSM_APPHElPER" : {
+        "location" : "tsm",
+        "anchor_link" : "",
+        "dl_url" : "https://www.tradeskillmaster.com/download/TradeSkillMaster_AppHelper.zip",
+        "last_updated" : ""
     }
 }

--- a/main.py
+++ b/main.py
@@ -306,14 +306,14 @@ def get_version_elvui(elv_url, ublock_xpi_path):
     # Wait for ElvUI version number to be visable, then grab it from tukui.org/welcome.php
     # There's always the possibility that Tukui changes the location of the version number.
     # If that happens, the XPATH below will break.
-    version = [my_elem.get_attribute("innerText") for my_elem in WebDriverWait(driver, 20).until(EC.visibility_of_all_elements_located((By.XPATH, "/html/body/div[2]/div/div/ul/li/div[4]/div/a[2]/span")))]
+    current_version = [my_elem.get_attribute("innerText") for my_elem in WebDriverWait(driver, 20).until(EC.visibility_of_all_elements_located((By.XPATH, "/html/body/div[2]/div/div/ul/li/div[4]/div/a[2]/span")))]
 
     # the above returns a list by default, so reassign "version" to the only element in the list
-    version = (version[0])
+    current_version = (current_version[0])
     
     driver.close()
 
-    return version
+    return current_version
 
 if __name__ == '__main__':
     main()

--- a/main.py
+++ b/main.py
@@ -101,12 +101,13 @@ def main():
         else:
             print(f'Processing {key}...')
             url_list.append(name['dl_url'])
-            to_be_updated.append(name)
+            to_be_updated.append(key)
 
     # let user know which addons we're updating because feedback is nice
     if len(to_be_updated) > 0:
         print(f'{colors.GREEN}The following addons will be updated:{colors.ENDC}')
-        print(to_be_updated)
+        for addon in to_be_updated:
+            print(addon)
     else:
         print(f'All World of Warcraft addons {colors.GREEN}up-to-date!{colors.ENDC}')
         quit()

--- a/main.py
+++ b/main.py
@@ -179,8 +179,7 @@ def main():
     # everything we've just downloaded. On the other hand, a graceful failure should leave the
     # system in the same state as it was before it ran. Problem for another day.
     try:
-        shutil.rmtree(addon_path)
-        shutil.move(dl_dir_addons, addon_path)
+        shutil.copytree(dl_dir_addons, addon_path, dirs_exist_ok=True)
     except Exception:
         print(f'{colors.FAIL}Error during folder move process...{colors.ENDC}')
         clean_downloads(addon_zips)


### PR DESCRIPTION
**BUGFIX**

Script would previously nuke entire addon folder when updating less than the total number of addons installed. Now, the script will only overwrite addons that need to be updated, leaving any addons that don't require updates alone. In other words, it works the way it's supposed to now.

**Optimizations**
- Bring back Trade Skill Master to the master addon list
- standardize variable names in get_version_elvui()
- Eliminate list notation in user feedback for to-be-updated addons
- small README change

