### PR TITLE
remove TSM from addon list and fix addon list typo

### DIFF
--- a/addon_master_list.json
+++ b/addon_master_list.json
@@ -15,7 +15,7 @@
 
     "DETAILS" : {
         "location" : "cf",
-        "anchor_link" : "https://www.curseforge.com/wow/addons/details/download",
+        "anchor_link" : "https://www.curseforge.com/wow/addons/details",
         "dl_url" : "https://www.curseforge.com/wow/addons/details/download",
         "last_updated" : ""
     },
@@ -74,19 +74,5 @@
         "anchor_link" : "https://www.tukui.org/welcome.php",
         "dl_url" : "https://www.tukui.org/downloads/elvui-",
         "current_version" : ""
-    },
-
-    "TSM" : {
-        "location" : "tsm",
-        "anchor_link" : "",
-        "dl_url" : "https://www.tradeskillmaster.com/download/TradeSkillMaster.zip",
-        "last_updated" : ""
-    },
-
-    "TSM_APPHElPER" : {
-        "location" : "tsm",
-        "anchor_link" : "",
-        "dl_url" : "https://www.tradeskillmaster.com/download/TradeSkillMaster_AppHelper.zip",
-        "last_updated" : ""
     }
 }


### PR DESCRIPTION
With the recent bugfix for overwriting the pre-script addon folder, I've removed Trade Skill Master and the TSM Application Helper from the master addon list. TSM simply doesn't receive many updates that necessitate updating the addon as a whole, and any version changes in the TSM manifest file are usually taken care of by the TSM desktop application that grabs a user's region and server data.

While there might be a new version of TSM released alongside Dragonflight (likely to add support for DF's crafting orders), it's beyond the scope of this script.