### PR TITLE
21 tukuielvui do not download

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Copy the following and add it to your addons_master_list.json and the script wil
     "ELVUI" : {
         "location" : "elvui",
         "anchor_link" : "https://www.tukui.org/elvui",
-        "dl_url" : "https://www.tukui.org/downloads/elvui#",
+        "dl_url" : "https://www.tukui.org/elvui",
         "current_version" : ""
     }
 
@@ -100,7 +100,7 @@ Copy the following and add it to your addons_master_list.json and the script wil
     "TUKUI" : {
         "location" : "tukui",
         "anchor_link" : "https://www.tukui.org/tukui",
-        "dl_url" : "https://www.tukui.org/downloads/tukui#",
+        "dl_url" : "https://tukui.org/tukui",
         "current_version" : ""
     }
 

--- a/addon_master_list.json
+++ b/addon_master_list.json
@@ -61,8 +61,8 @@
     },
     "ELVUI": {
         "location": "tukui",
-        "anchor_link": "https://www.tukui.org/welcome.php",
-        "dl_url": "https://www.tukui.org/downloads/elvui#",
+        "anchor_link": "https://tukui.org/elvui",
+        "dl_url": "https://tukui.org/elvui",
         "current_version": "13.29"
     }
 }

--- a/addon_master_list.json
+++ b/addon_master_list.json
@@ -60,7 +60,7 @@
         "last_updated": "1681838984"
     },
     "ELVUI": {
-        "location": "elvui",
+        "location": "tukui",
         "anchor_link": "https://www.tukui.org/welcome.php",
         "dl_url": "https://www.tukui.org/downloads/elvui#",
         "current_version": "13.29"

--- a/main.py
+++ b/main.py
@@ -162,7 +162,7 @@ def main():
 
     for url in tukui_url_list:
         print(f'Opening {colors.GREEN}{url}{colors.ENDC}')
-        download_tuk_addon()
+        download_tuk_addon(url, ublock_xpi_path)
         dl_dir_count += 1
 
     addon_zips = []
@@ -331,6 +331,7 @@ def get_version_tuk_addon(tuk_url, ublock_xpi_path):
     version_list = [my_elem.get_attribute("innerText") for my_elem in WebDriverWait(driver, 20).until(EC.visibility_of_all_elements_located((By.XPATH, '//*[@id="download-button"]')))]
     # the above returns a list by default, so reassign "version" to the the first element in the list.
     version_item = version_list[0]
+
     version_split = version_item.split()
     current_version = (version_split[-1])
 
@@ -349,7 +350,8 @@ def download_tuk_addon(tuk_url, ublock_xpi_path):
     driver.install_addon(ublock)
     driver.get(tuk_url)
     WebDriverWait(driver, 20).until(EC.visibility_of_all_elements_located((By.XPATH, '//*[@id="download-button"]')))
-    driver.findElement(By.id("download-button")).click();
+    sleep(2)
+    driver.find_element(By.XPATH, '//*[@id="download-button"]').click();
     sleep(5)
 
     driver.close()

--- a/main.py
+++ b/main.py
@@ -93,17 +93,9 @@ def main():
                 continue
     # Here we do the same for TukUI and ElvUI, with the only difference being we check
     # current_version instead of current version time.
-        elif name['location'] == 'elvui':
-            print(f'Processing {key}...')
-            current_version = get_version_elvui(name['anchor_link'], ublock_xpi_path)
-            if current_version != name['current_version']:
-                dl_url = (f"{name['dl_url']}")
-                tukui_url_list.append(dl_url)
-                to_be_updated.append(key)
-                name['current_version'] = current_version
         elif name['location'] == 'tukui':
             print(f'Processing {key}...')
-            current_version = get_version_tukui(name['anchor_link'], ublock_xpi_path)
+            current_version = get_version_tuk_addon(name['anchor_link'], ublock_xpi_path)
             if current_version != name['current_version']:
                 dl_url = (f"{name['dl_url']}")
                 tukui_url_list.append(dl_url)
@@ -320,7 +312,7 @@ def get_cf_update_time(cf_url, ublock_xpi_path):
 
     return last_updated
 
-def get_version_elvui(elv_url, ublock_xpi_path):
+def get_version_tuk_addon(elv_url, ublock_xpi_path):
     '''Start an instance of the Selenium browser, activate the uBlock origin .xpi file
     from the provided ublock_xpi_path, navigate to the Tukui Homepage url (elv_url),
     and grab and return the addon's version number from the url.'''
@@ -335,9 +327,7 @@ def get_version_elvui(elv_url, ublock_xpi_path):
     driver.install_addon(ublock)
     driver.get(elv_url)
 
-    # Wait for ElvUI version number to be visable, then grab it from tukui.org/welcome.php
-    # There's always the possibility that Tukui changes the location of the version number.
-    # If that happens, the XPATH below will break.
+    # Wait for addon version number to be visable, then grab it from the download button.
     version_list = [my_elem.get_attribute("innerText") for my_elem in WebDriverWait(driver, 20).until(EC.visibility_of_all_elements_located((By.XPATH, '//*[@id="download-button"]')))]
     # the above returns a list by default, so reassign "version" to the the first element in the list.
     version_item = version_list[0]
@@ -348,38 +338,10 @@ def get_version_elvui(elv_url, ublock_xpi_path):
 
     return current_version
 
-def get_version_tukui(tukui_url, ublock_xpi_path):
-    '''Start an instance of the Selenium browser, activate the uBlock origin .xpi file
-    from the provided ublock_xpi_path, navigate to the Tukui Homepage url (elv_url),
-    and grab and return the addon's version number from the url.'''
-    driver = start_browser()
-
-    if os.name == 'nt':
-        # Windows panics if we don't pass this as a raw string
-        ublock = fr"{ublock_xpi_path}"
-    else:
-        ublock = ublock_xpi_path
-
-    driver.install_addon(ublock)
-    driver.get(tukui_url)
-
-    # Wait for ElvUI version number to be visable, then grab it from tukui.org/welcome.php
-    # There's always the possibility that Tukui changes the location of the version number.
-    # If that happens, the XPATH below will break.
-    current_version = [my_elem.get_attribute("innerText") for my_elem in WebDriverWait(driver, 20).until(EC.visibility_of_all_elements_located((By.XPATH, "/html/body/div[2]/div/div/ul/li/div[4]/div/a[1]/span")))]
-
-    # the above returns a list by default, so reassign "version" to the the first element in the list
-    current_version = (current_version[0])
-    
-    driver.close()
-
-    return current_version
-
 def download_tuk_addon(elv_url, ublock_xpi_path):
     driver = start_visible_browser()
 
     if os.name == 'nt':
-        # Windows panics if we don't pass this as a raw string
         ublock = fr"{ublock_xpi_path}"
     else:
         ublock = ublock_xpi_path

--- a/main.py
+++ b/main.py
@@ -312,9 +312,9 @@ def get_cf_update_time(cf_url, ublock_xpi_path):
 
     return last_updated
 
-def get_version_tuk_addon(elv_url, ublock_xpi_path):
+def get_version_tuk_addon(tuk_url, ublock_xpi_path):
     '''Start an instance of the Selenium browser, activate the uBlock origin .xpi file
-    from the provided ublock_xpi_path, navigate to the Tukui Homepage url (elv_url),
+    from the provided ublock_xpi_path, navigate to the Tukui Homepage url (tuk_url),
     and grab and return the addon's version number from the url.'''
     driver = start_browser()
 
@@ -325,7 +325,7 @@ def get_version_tuk_addon(elv_url, ublock_xpi_path):
         ublock = ublock_xpi_path
 
     driver.install_addon(ublock)
-    driver.get(elv_url)
+    driver.get(tuk_url)
 
     # Wait for addon version number to be visable, then grab it from the download button.
     version_list = [my_elem.get_attribute("innerText") for my_elem in WebDriverWait(driver, 20).until(EC.visibility_of_all_elements_located((By.XPATH, '//*[@id="download-button"]')))]
@@ -338,7 +338,7 @@ def get_version_tuk_addon(elv_url, ublock_xpi_path):
 
     return current_version
 
-def download_tuk_addon(elv_url, ublock_xpi_path):
+def download_tuk_addon(tuk_url, ublock_xpi_path):
     driver = start_visible_browser()
 
     if os.name == 'nt':
@@ -347,7 +347,7 @@ def download_tuk_addon(elv_url, ublock_xpi_path):
         ublock = ublock_xpi_path
 
     driver.install_addon(ublock)
-    driver.get(elv_url)
+    driver.get(tuk_url)
     WebDriverWait(driver, 20).until(EC.visibility_of_all_elements_located((By.XPATH, '//*[@id="download-button"]')))
     driver.findElement(By.id("download-button")).click();
     sleep(5)


### PR DESCRIPTION
Fixed issue by calling .click() on the download button for both TukUI and ElvUI addons. Simplified logic and refactored TukUI download functions. Both ElvUI and TukUI addons now version check and download successfully. 