### PR TITLE
Switch to using Python's tempfile lib for temp dir creation

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,8 +23,6 @@ class colors:
     BOLD = '\033[1m'
 
 def main():
-    # Start the Selenium instances at the beginning of the script
-    start_browsers()
 
     try:
         parser = argparse.ArgumentParser()
@@ -51,7 +49,10 @@ def main():
                 quit()
             else:
                 continue
-            
+        
+        # Start the Selenium instances at the beginning of the script
+        start_browsers()
+
         # clear geckodriver.log
         if os.path.exists('geckodriver.log'):
             open('geckodriver.log', 'w').close


### PR DESCRIPTION
This PR closes https://github.com/Lesona-Systems/Underwolf/issues/35 by removing manual temporary addon dir creating and instead using Python's tempfile lib to create a new, temporary directory at the OS level where the OS expects it.